### PR TITLE
Variables not being compiled into @FontFace URLs within SASS stylesheet

### DIFF
--- a/sass/elusive-webfont.scss
+++ b/sass/elusive-webfont.scss
@@ -2,11 +2,11 @@ $elusiveWebfontPath: '../fonts/';
 $Elusive-iconfontVersion: 2;
 @font-face {
 	font-family: 'Elusive-Icons';
-	src:url('#{elusiveWebfontPath}Elusive-Icons.eot?v=#{Elusive-iconfontVersion}');
-	src:url('#{elusiveWebfontPath}Elusive-Icons.eot?#iefix&v=#{Elusive-iconfontVersion}') format('embedded-opentype'),
-		url('#{elusiveWebfontPath}Elusive-Icons.svg#Elusive-Icons?v=#{Elusive-iconfontVersion}') format('svg'),
-		url('#{elusiveWebfontPath}Elusive-Icons.woff?v=#{Elusive-iconfontVersion}') format('woff'),
-		url('#{elusiveWebfontPath}Elusive-Icons.ttf?v=#{Elusive-iconfontVersion}') format('truetype');
+	src:url('#{$elusiveWebfontPath}Elusive-Icons.eot?v=#{$Elusive-iconfontVersion}');
+	src:url('#{$elusiveWebfontPath}Elusive-Icons.eot?#iefix&v=#{$Elusive-iconfontVersion}') format('embedded-opentype'),
+		url('#{$elusiveWebfontPath}Elusive-Icons.svg#Elusive-Icons?v=#{$Elusive-iconfontVersion}') format('svg'),
+		url('#{$elusiveWebfontPath}Elusive-Icons.woff?v=#{$Elusive-iconfontVersion}') format('woff'),
+		url('#{$elusiveWebfontPath}Elusive-Icons.ttf?v=#{$Elusive-iconfontVersion}') format('truetype');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
A missing $ in the variable interpolation within the SASS stylesheet is preventing the variables from being compiled into the @FontFace URLs.
